### PR TITLE
通过 `manifest` 中的 `slug` 或 `name` 来寻找 release 中的 zip 文件

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -756,7 +756,7 @@ async function install(release = false): Promise<HandleResult> {
   config.debug && console.log('install', currentItem)
 
   if (release) {
-    const urlObj = await getLatestReleaseUrl(currentItem)
+    const urlObj = await getLatestReleaseUrl(currentItem, currentManifest)
     if (urlObj.zip) {
       url = urlObj.zip
     } else if (urlObj.message) {
@@ -833,7 +833,7 @@ function getArchiveUrl(item: Plugin) {
   return `https://github.com/${item.repo}/archive/refs/heads/${item.branch}.zip`
 }
 
-async function getLatestReleaseUrl(item: Plugin): Promise<{ zip: string | undefined; ball: string; message: string | undefined }> {
+async function getLatestReleaseUrl(item: Plugin, manifest: Manifest): Promise<{ zip: string | undefined; ball: string; message: string | undefined }> {
   const url = `https://api.github.com/repos/${item.repo}/releases/latest`
   const headers: Record<string, string> = {}
   if (config.githubToken) {
@@ -846,7 +846,9 @@ async function getLatestReleaseUrl(item: Plugin): Promise<{ zip: string | undefi
     .catch(err => {
       throw new Error(`${err.message} \n${url}`)
     })
-  const zipFile = body.assets?.find?.(asset => asset.name.endsWith('.zip'))
+  const zipFile = body.assets?.find?.(asset => asset.name === (`${manifest.slug}.zip`))
+    ?? body.assets?.find?.(asset => asset.name === (`${manifest.name}.zip`))
+    ?? body.assets?.find?.(asset => asset.name.endsWith('.zip'))
   return {
     zip: zipFile?.browser_download_url,
     ball: `https://github.com/${item.repo}/archive/refs/tags/${body.tag_name}.zip`, //body.zipball_url


### PR DESCRIPTION
原始方案是直接从 release 的 assets 中定位扩展名为 `.zip` 的文件，修改后则是试图定位 `${slug}.zip` 或 `${name}.zip`。

这样主要是出于方便[部分项目在 Release 中发布适用于不同加载方式的构建](https://github.com/NapNeko/NapCatQQ/releases)的考虑。同时，[LiteLoaderQQNT-PluginTemplate-Vite 的构建脚本](https://github.com/MisaLiu/LiteLoaderQQNT-PluginTemplate-Vite/blob/master/electron.vite.config.ts#L61)也使用 `slug` 作为构建出的工件的文件名。

这一改动对现存的大多数插件的安装不造成影响，因为仍然提供了最终的 fallback 方案，也就是寻找任意 zip 文件作为插件的 latest release。